### PR TITLE
Security: Upgrade rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,22 +1,55 @@
-Documentation:
-  Enabled: false
+################################################################################
+#                                                                              #
+#                    Rules that depart from rubocop defaults                   #
+#                                                                              #
+################################################################################
 
-TrailingComma:
-  EnforcedStyleForMultiline: comma
-
-AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
-SingleLineBlockParams:
+Style/Documentation:
   Enabled: false
 
-MethodLength:
+Metrics/MethodLength:
   Max: 15
 
-CollectionMethods:
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/CollectionMethods:
   PreferredMethods:
     collect: 'map'
     collect!: 'map!'
     inject: 'reduce'
     find: 'detect'
     find_all: 'select'
+
+
+################################################################################
+#                                                                              #
+#                            Rules we want to enable                           #
+#                                                                              #
+################################################################################
+
+# Default -> Max: 100
+Metrics/ModuleLength:
+  Max: 124
+
+# Default -> Max: 25
+Metrics/BlockLength:
+  Max: 104
+
+################################################################################
+#                                                                              #
+#                         Rules we don't want to enable                        #
+#                                                                              #
+################################################################################
+
+Style/SingleLineBlockParams:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ rvm:
   - 2.4.3
 script:
   - bundle exec rake
-  - rubocop -D
+  - bundle exec rubocop -D
   - bundle exec travis lint --skip-completion-check
   - gem build email_repair.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in email_repair.gemspec
 gemspec
 
-gem 'rake'
-gem 'rspec'
-gem 'rubocop', '~> 0.27.0'
-gem 'travis'
-gem 'coveralls'
+gem 'coveralls', '~> 0.8.21'
+gem 'rake', '~> 12.3.1'
+gem 'rspec', '~> 3.7.0'
+gem 'rubocop', '~> 0.54.0'
+gem 'travis', '~> 1.8.8'

--- a/email_repair.gemspec
+++ b/email_repair.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'email_repair/version'
 require 'English'
@@ -14,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = Dir['{lib}/**/*', 'LICENSE', 'README.md']
-  spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{^bin\/}) { |f| File.basename(f) }
   spec.test_files    = Dir['spec/**/*']
   spec.require_paths = ['lib']
 end

--- a/lib/email_repair/mechanic.rb
+++ b/lib/email_repair/mechanic.rb
@@ -42,10 +42,10 @@ module EmailRepair
     class CommonMistakeRepair
       def self.repair(email)
         email.downcase
-          .gsub(/\s/, '')
-          .sub(/@+/, '@')
-          .sub(/\.c0m$/, '.com')
-          .sub(/,[a-z]{2,24}$/) { |m| m.sub(',', '.') }
+             .gsub(/\s/, '')
+             .sub(/@+/, '@')
+             .sub(/\.c0m$/, '.com')
+             .sub(/,[a-z]{2,24}$/) { |m| m.sub(',', '.') }
       end
     end
 
@@ -58,7 +58,7 @@ module EmailRepair
 
     class CommonDomainRepair
       def self.repair(*)
-        fail 'not implemented'
+        raise 'not implemented'
       end
 
       def self.common_domains
@@ -78,7 +78,7 @@ module EmailRepair
     class CommonDomainSuffixRepair < CommonDomainRepair
       def self.repair(email)
         common_domains.each do |name, suffix|
-          email = "#{email}.#{suffix}" if email.match(/#{name}$/)
+          email = "#{email}.#{suffix}" if email.match?(/#{name}$/)
         end
         email
       end
@@ -100,7 +100,7 @@ module EmailRepair
           punc_regex = /[.#-]#{name}.#{suffix}$/
           if email.match(punc_regex)
             email = email.sub(punc_regex, "@#{name}.#{suffix}")
-          elsif email.match(/[^@]#{name}.#{suffix}$/)
+          elsif email.match?(/[^@]#{name}.#{suffix}$/)
             email = email.sub(/#{name}.#{suffix}$/, "@#{name}.#{suffix}")
           end
         end

--- a/lib/email_repair/version.rb
+++ b/lib/email_repair/version.rb
@@ -1,3 +1,3 @@
 module EmailRepair
-  VERSION = '0.2.0'
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/lib/email_repair/mechanic_spec.rb
+++ b/spec/lib/email_repair/mechanic_spec.rb
@@ -2,12 +2,11 @@ require 'spec_helper'
 
 module EmailRepair
   describe Mechanic, '#repair_all' do
-
     it 'sanitizes an array of emails and returns bulk results' do
       mechanic = Mechanic.new
-      salvageable_emails = %w(One@@two.com three@four.com one@twO.com)
-      sanitized_emails = %w(one@two.com three@four.com)
-      bad_emails = %w(bleep@blop plooooooop plooOOooop)
+      salvageable_emails = %w[One@@two.com three@four.com one@twO.com]
+      sanitized_emails = %w[one@two.com three@four.com]
+      bad_emails = %w[bleep@blop plooooooop plooOOooop]
 
       result = mechanic.repair_all(salvageable_emails + bad_emails)
       expect(result.sanitized_emails).to match_array sanitized_emails
@@ -23,7 +22,6 @@ module EmailRepair
       expect(result.sanitized_emails).to eq ['bleep@bloop.com']
       expect(result.invalid_emails).to eq []
     end
-
   end
 
   describe Mechanic, '#repair' do
@@ -34,7 +32,7 @@ module EmailRepair
       # http://www.stuffaboutcode.com/2013/02/validating-email-address-bloody.html
       # List of longest TLDs
       # https://jasontucker.blog/8945/what-is-the-longest-tld-you-can-get-for-a-domain-name
-      good_emails = %w(
+      good_emails = %w[
         b@b.com
         lobatifricha@gmail.com
         mrspicy+whocares@whatevs.com
@@ -43,7 +41,7 @@ module EmailRepair
         b@mps.school
         b@kickstarter.engineering
         b@joyful.christmas
-      )
+      ]
 
       good_emails.each do |good_email|
         expect(mechanic.repair(good_email)).to eq good_email
@@ -73,7 +71,7 @@ module EmailRepair
     end
 
     it 'adds missing .com' do
-      no_com_mails = %w(blah@gmail bloo@yahoo blee@hotmail)
+      no_com_mails = %w[blah@gmail bloo@yahoo blee@hotmail]
       no_com_mails.each do |no_com_mail|
         expect(mechanic.repair(no_com_mail)).to eq "#{no_com_mail}.com"
       end


### PR DESCRIPTION
**depends on #16**

There's a low-severity security vulnerability associated with older
versions of rubocop:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418

This PR:
- Organizes `rubocop.yml` the way Synchroform's is organized (rules
that depart from defaults / rules we want to enable / rules we don't
want to enable)
- Adds module prefixes to the rules in `rubocop.yml` (e.g.
'Style/Documentation' instead of just 'Documentation')
- makes changes to accommodate the following rules:
  - [Performance/RedundantMatch](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Performance/RedundantMatch)
  - [Style/SignalException](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SignalException)
  - [Layout/MultilineMethodCallIndentation](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineMethodCallIndentation)
  - [Style/MutableConstant](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MutableConstant)
  - [Style/PercentLiteralDelimiter](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/PercentLiteralDelimiter)
  - [Style/EmptyLinesAroundBlockBody](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyLinesAroundBlockBody)
  - [Style/ExpandPathArguments](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ExpandPathArguments)
  - [Bundler/OrderedGems](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Bundler/OrderedGems)
  - [Layout/EmptyLineAfterMagicComment](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLineAfterMagicComment)
  - [Style/Encoding](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Encoding)
- Sets higher maximums to accommodate the current state of our code:
  - [Metrics/ModuleLength](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/ModuleLength)
  - [Metrics/BlockLength](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/BlockLength)