### PR TITLE
Add description and documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ the emails that were unable to be repaired
 
 #### EmailRepair::Constants::email_regex
 
-Returns a regular expression to be used to validate user supplied email
+Returns a regular expression to be used to validate user-supplied email
 addresses.
 
 ### Available Repairs


### PR DESCRIPTION
Adds a short description and documentation of Email Repair's public
methods to the README.

resolves #18