### PR TITLE
Allow capitals in email regex

### DIFF
--- a/lib/email_repair/constants.rb
+++ b/lib/email_repair/constants.rb
@@ -4,7 +4,7 @@ module EmailRepair
       def email_regex
         local_part_regex = "[#{valid_chars}]" \
           "([#{valid_chars_with_dot}]*[#{valid_chars}])?"
-        /#{local_part_regex}@(?:[a-z0-9\-]+\.)+(?:[a-z]{2,24})/
+        /#{local_part_regex}@(?:[a-zA-Z0-9\-]+\.)+(?:[a-zA-Z]{2,24})/
       end
 
     private
@@ -14,7 +14,7 @@ module EmailRepair
       end
 
       def valid_chars
-        'a-z0-9_%\+\-\''
+        'a-zA-Z0-9_%\+\-\''
       end
     end
   end

--- a/lib/email_repair/version.rb
+++ b/lib/email_repair/version.rb
@@ -1,3 +1,3 @@
 module EmailRepair
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/lib/email_repair/constants_spec.rb
+++ b/spec/lib/email_repair/constants_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+module EmailRepair
+  describe Constants, '.email_regex' do
+    it 'allows capital letters' do
+      expect('ICan.CaPitAliZe@hOwI.WanT')
+        .to match(/\A#{EmailRepair::Constants.email_regex}\z/)
+    end
+  end
+end


### PR DESCRIPTION
Updates the regular expression to allow capital letters so that we can
use it for frontend validation without rejecting valid emails.
