### PR TITLE
Prevent CommonDomainAtAdder from adding extra @s

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,6 +18,9 @@ Gemspec/RequiredRubyVersion:
 # AllowedMethods: refine
 Metrics/BlockLength:
   Max: 104
+  Exclude:
+    - 'spec/lib/email_repair/mechanic_spec.rb'
+
 
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
@@ -28,6 +31,8 @@ Metrics/MethodLength:
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
   Max: 124
+  Exclude:
+    - 'spec/lib/email_repair/mechanic_spec.rb'
 
 # Offense count: 10
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/lib/email_repair/mechanic.rb
+++ b/lib/email_repair/mechanic.rb
@@ -96,8 +96,11 @@ module EmailRepair
 
     class CommonDomainAtAdder < CommonDomainRepair
       def self.repair(email)
+        return email if email.match('.+@.+\..+')
+
         common_domains.each do |name, suffix|
           punc_regex = /[.#-]#{name}.#{suffix}$/
+
           if email.match(punc_regex)
             email = email.sub(punc_regex, "@#{name}.#{suffix}")
           elsif email.match?(/[^@]#{name}.#{suffix}$/)

--- a/lib/email_repair/version.rb
+++ b/lib/email_repair/version.rb
@@ -1,3 +1,3 @@
 module EmailRepair
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end

--- a/spec/lib/email_repair/mechanic_spec.rb
+++ b/spec/lib/email_repair/mechanic_spec.rb
@@ -123,6 +123,10 @@ module EmailRepair
       end
     end
 
+    it 'does not add an extra @ if there is already one' do
+      expect(mechanic.repair('bloo@myyahoo.com')).to eq 'bloo@myyahoo.com'
+    end
+
     it 'replaces , with .' do
       expect(mechanic.repair('b@b,com')).to eq 'b@b.com'
     end


### PR DESCRIPTION
The CommonDomainAtAdder would add an extra `@` if the email's domain
contained a common domain as a suffix. That is, an email like
`foo@myyahoo.com` would get transformed into `foo@my@yahoo.com` by the
CommonDomainAtAdder then transformed to `my@yahoo.com` by
EmailRegexRepair.

This resolves the issue by exiting the CommonDomainAtAdder early if the
email already has all the email parts including an `@`.

Co-authored-by: Juan Cervantes <juan@informedk12.com>
